### PR TITLE
Change build archive name and remove .env from prod build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# mac files
+.DS_STORE

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,10 +1,6 @@
 const path = require('path');
-const CopyPlugin = require('copy-webpack-plugin');
 const AwsSamPlugin = require('aws-sam-webpack-plugin');
-
 const awsSamPlugin = new AwsSamPlugin({ vscodeDebug: false });
-const GETALL_LAMBDA_NAME = "GetAllLambdaFunction"; 
-const GET_LAMBDA_NAME = "GetLambdaFunction";
 
 module.exports = {
   // Loads the entry object from the AWS::Serverless::Function resources in your
@@ -33,12 +29,6 @@ module.exports = {
 
   // Add the AWS SAM Webpack plugin
   plugins: [
-    awsSamPlugin,
-    new CopyPlugin({
-      patterns: [
-        { from: './.env', to: `.aws-sam/build/${GETALL_LAMBDA_NAME}/` },
-        { from: './.env', to: `.aws-sam/build/${GET_LAMBDA_NAME}/` },
-      ],
-    }),
+    awsSamPlugin
   ]
 };

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,7 +1,19 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const CopyPlugin = require('copy-webpack-plugin');
+
+const GETALL_LAMBDA_NAME = "GetAllLambdaFunction";
+const GET_LAMBDA_NAME = "GetLambdaFunction";
 
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'source-map',
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: './.env', to: `.aws-sam/build/${GETALL_LAMBDA_NAME}/` },
+        { from: './.env', to: `.aws-sam/build/${GET_LAMBDA_NAME}/` },
+      ],
+    }),
+  ]
 });

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -6,8 +6,9 @@ const branchName = require('current-git-branch');
 
 const GETALL_LAMBDA_NAME = "GetAllLambdaFunction"; 
 const GET_LAMBDA_NAME = "GetLambdaFunction";
-const OUTPUT_FOLDER = './dist'
-const BUILD_VERSION = branchName().replace("/","-");
+const OUTPUT_FOLDER = './dist';
+const REPO_NAME = `hvt-read-api`;
+const BRANCH_NAME = branchName().replace("/","-");
 
 class BundlePlugin {
   constructor(params) {
@@ -41,11 +42,11 @@ class BundlePlugin {
     archive.on('error', function(err){
         throw err;
     });
-    
+
     archive.pipe(output);
     archive.glob(
-      `**/*`, 
-      { 
+      `**/*`,
+      {
         cwd: inputPath,
         skip: ignore
       }
@@ -54,22 +55,25 @@ class BundlePlugin {
   }
 };
 
-module.exports = merge(common, {
-  mode: 'production',
-  plugins: [
-    new BundlePlugin({
-      archives: [
-        {
-          inputPath: `.aws-sam/build/${GETALL_LAMBDA_NAME}`,
-          outputPath: `${OUTPUT_FOLDER}`,
-          outputName: `HVT-${GETALL_LAMBDA_NAME}-${BUILD_VERSION}`,
-        },
-        {
-          inputPath: `.aws-sam/build/${GET_LAMBDA_NAME}`,
-          outputPath: `${OUTPUT_FOLDER}`,
-          outputName: `HVT-${GET_LAMBDA_NAME}-${BUILD_VERSION}`,
-        }
-      ],
-    }),
-  ],
-});
+module.exports = env => {
+  let commit = env ? env.commit ? env.commit : 'local' : 'local' ;
+  return merge(common, {
+    mode: 'production',
+    plugins: [
+      new BundlePlugin({
+        archives: [
+          {
+            inputPath: `.aws-sam/build/${GETALL_LAMBDA_NAME}`,
+            outputPath: `${OUTPUT_FOLDER}`,
+            outputName: `${REPO_NAME}-${GETALL_LAMBDA_NAME}-${BRANCH_NAME}-${commit}`,
+          },
+          {
+            inputPath: `.aws-sam/build/${GET_LAMBDA_NAME}`,
+            outputPath: `${OUTPUT_FOLDER}`,
+            outputName: `${REPO_NAME}-${GET_LAMBDA_NAME}-${BRANCH_NAME}-${commit}`,
+          }
+        ],
+      }),
+    ],
+    })
+};


### PR DESCRIPTION
- Optionally pass in commit id when building so the zip file
is named correctly through build config files, not through
Jenkinsfile scripts
- Pipeline can now call build command:
`npm run build:prod -- --env.commit=<commit-hash>`
- Remove the .env file from prod builds as this file is only required
for dev builds and should not be included
- Ticket #BL-11943